### PR TITLE
Moved logging of API call results to debug level

### DIFF
--- a/cb-defense-syslog.py
+++ b/cb-defense-syslog.py
@@ -355,7 +355,6 @@ def main():
 
         if not response:
             logger.warn("Received unexpected (or no) response from Cb Defense Server {0}. Proceeding to next connector.".format(server.get('server_url')))
-            #sys.exit(-1)
             continue
 
         #

--- a/cb-defense-syslog.py
+++ b/cb-defense-syslog.py
@@ -79,10 +79,10 @@ def parse_config():
 
 
 def send_syslog_tls(server_url, port, data, output_type):
-
+    data += '\n'
     if output_type == 'tcp+tls':
         unsecured_client_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-
+        
         try:
 
             if config.getboolean('tls', 'tls_verify'):
@@ -354,7 +354,7 @@ def main():
                                              False)
 
         if not response:
-            logger.warn("Got no response from Cb Defense Server {0}. Proceeding to next connector".format(server.get('server_url')))
+            logger.warn("Received unexpected (or no) response from Cb Defense Server {0}. Proceeding to next connector.".format(server.get('server_url')))
             #sys.exit(-1)
             continue
 

--- a/cb-defense-syslog.py
+++ b/cb-defense-syslog.py
@@ -380,7 +380,6 @@ def main():
             #
             for log in log_messages:
                 template = Template(config.get('general', 'template'))
-                template = Template(config.get('general', 'template'))
                 send_syslog_tls(output_params['output_host'],
                             output_params['output_port'],
                             template.render(log),

--- a/cb-defense-syslog.py
+++ b/cb-defense-syslog.py
@@ -32,6 +32,9 @@ def cb_defense_server_request(url, api_key, connector_id, ssl_verify):
         if response.status_code == 401:
             logger.warn("Authentication failed check config file for proper Connector ID and API key")
             sys.exit(1)
+        elif response.status_code != 200:
+            logger.warn("Cb Defense API did not return a Success code. Exiting the loop.")
+            return None 
     except Exception as e:
         logging.error(e, exc_info=True)
         return None
@@ -351,8 +354,9 @@ def main():
                                              False)
 
         if not response:
-            logger.error("Got no response from Cb Defense Server {0}".format(server.get('server_url')))
-            sys.exit(-1)
+            logger.warn("Got no response from Cb Defense Server {0}. Proceeding to next connector".format(server.get('server_url')))
+            #sys.exit(-1)
+            continue
 
         #
         # perform fixups

--- a/cb-defense-syslog.py
+++ b/cb-defense-syslog.py
@@ -351,14 +351,13 @@ def main():
                                              False)
 
         if not response:
-            logger.error("got no response from Cb Defense Server")
+            logger.error("Got no response from Cb Defense Server {0}".format(server.get('server_url')))
             sys.exit(-1)
 
         #
         # perform fixups
         #
-        #response = fix_response(response.content)
-        logger.info(response.content)
+        logger.debug(response.content)
         json_response = json.loads(response.content)
 
         #


### PR DESCRIPTION
The logging of the call to retrieve queued up events from the connector in CbD was set at "INFO" which means it was being logged by default.

That can be quite voluminous so it makes more sense to only log it when in debug mode.