### PR TITLE
change username from 'daemon' to 'root' in crontab

### DIFF
--- a/root/etc/cron.d/cb-defense-syslog
+++ b/root/etc/cron.d/cb-defense-syslog
@@ -17,4 +17,4 @@
 #
 # Uncomment to enable the cb-defense-connector with cron
 #
-#  0  *  *  *  * daemon /usr/share/cb/integrations/cb-defense-syslog/cb-defense-syslog --config-file /etc/cb/integrations/cb-defense-syslog/cb-defense-syslog.conf --log-file /var/log/cb/integrations/cb-defense-syslog/cb-defense-syslog.log
+#  0  *  *  *  * root /usr/share/cb/integrations/cb-defense-syslog/cb-defense-syslog --config-file /etc/cb/integrations/cb-defense-syslog/cb-defense-syslog.conf --log-file /var/log/cb/integrations/cb-defense-syslog/cb-defense-syslog.log


### PR DESCRIPTION
The log directory is created with permissions only writable by 'root' - change the crontab so it will run as 'root' rather than 'daemon'.