### PR TITLE
Missing requirement dependency "six"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Jinja2==2.8
 MarkupSafe==0.23
 requests>=2.20.0
 flask==0.12.4
+six==1.12.0


### PR DESCRIPTION
From cb_defense_syslog.py, row 26:
from six import PY2
https://pypi.org/project/six/