### PR TITLE
Added HTTP Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,21 +91,32 @@ Debug Logs are stored in `/var/log/cb/integrations/cb-defense-syslog/`
     output_type=tcp
 
     #
-	# Output format of the data sent. Currently support json or cef formats
-	#
-	# Warning: if using json output_format, we recommend NOT using UDP output_type
-	#
-	output_format=cef
+  	# Output format of the data sent. Currently support json or cef formats
+  	#
+  	# Warning: if using json output_format, we recommend NOT using UDP output_type
+  	#
+  	output_format=cef
 
     #
-    # tcpout=IP:port - ie 1.2.3.5:8080
+    # Configure the specific output.
+    # Valid options are: 'udp', 'tcp', 'tcp+tls', 'http'
     #
-    tcp_out=
+    #  udp     - Have the events sent over a UDP socket
+    #  tcp     - Have the events sent over a TCP socket
+    #  tcp+tls - Have the events sent over a TLS+TCP socket
+    #  http    - Have the events sent over a HTTP connection
+    #
+    output_type=tcp
 
     #
     # udpout=IP:port - ie 1.2.3.5:8080
     #
     udp_out=
+
+    #
+    # httpout=Http endpoint - ie https://server.company.com/endpoint
+    #
+    http_out=
 
     [tls]
 

--- a/root/etc/cb/integrations/cb-defense-syslog/cb-defense-syslog.conf.example
+++ b/root/etc/cb/integrations/cb-defense-syslog/cb-defense-syslog.conf.example
@@ -38,11 +38,12 @@ output_format=cef
 
 #
 # Configure the specific output.
-# Valid options are: 'udp', 'tcp', 'tcp+tls'
+# Valid options are: 'udp', 'tcp', 'tcp+tls', 'http'
 #
 #  udp     - Have the events sent over a UDP socket
 #  tcp     - Have the events sent over a TCP socket
 #  tcp+tls - Have the events sent over a TLS+TCP socket
+#  http    - Have the events sent over a HTTP connection
 #
 output_type=tcp
 
@@ -55,6 +56,11 @@ tcp_out=
 # udpout=IP:port - ie 1.2.3.5:514
 #
 udp_out=
+
+#
+# httpout=Http endpoint - ie https://server.company.com/endpoint
+#
+http_out=
 
 #
 # Override ca file for self signed certificates


### PR DESCRIPTION
Added HTTP Support to send the CB Defense Events to a HTTP Endpoint.
A new config option is added in config file "http_out". The http endpoint needs to be added to http_out parameter.

The output_type needs to be set as http to use the HTTP Endpoint option.